### PR TITLE
Fix crash when no class folder : Fix #2

### DIFF
--- a/src/@Documentor/autoassigndocfiles.m
+++ b/src/@Documentor/autoassigndocfiles.m
@@ -47,8 +47,10 @@ function [] = autoassigndocfiles( Dr, outputDir )
 
     % ignore @class directories: class documentation goes to parent folder
     isClassDir            = contains( subDirs, filesep + "@" ) ;
-    subDirs( isClassDir ) = parent( subDirs( isClassDir ), 'single' ) ;
-
+    if any(isClassDir)
+        subDirs( isClassDir ) = parent( subDirs( isClassDir ), 'single' ) ;
+    end
+    
     % assign file name(s)
     docFiles = fullfile( outputDir, subDirs, names + ".md" ) ;
     

--- a/src/fUtilities/parent.m
+++ b/src/fUtilities/parent.m
@@ -51,6 +51,12 @@ function [parentDir] = parent( pathIn, level )
         pathIn {mustBeStringOrCharOrCellstr}
         level {mustBeMember(level,["single" "common"])} = "single" ;
     end
+    
+% Return empty array if input path is empty    
+if isempty(pathIn)
+    parentDir = [] ;
+    return
+end
 
 P = Pathologist( pathIn ) ;
 


### PR DESCRIPTION
Skipped the [call](https://github.com/shimming-toolbox/helpDocMd/blob/37b764d5663484b57c49324ab37e7eef22dad7dd/src/%40Documentor/autoassigndocfiles.m#L50) to parent folder when no class folder is to be documented
Also added within [parent](https://github.com/shimming-toolbox/helpDocMd/blob/37b764d5663484b57c49324ab37e7eef22dad7dd/src/fUtilities/parent.m#L56) a call to output an empty array when an empty array is fed as input